### PR TITLE
Type narrowing improvements and graphql parent type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Improvements to codegen when using GraphQL types and interfaces in parent or return positions
 
+- When a resolver is simply a fn to a literal, narrow to that exact type in the codegen (instead of keeping the optional promise type)
+
 ### 1.0.2
 
 - Better prettier detection (and fallback) for the generated files, re #14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Better handling of modern prettier versions
 
+- Improvements to codegen when using GraphQL types and interfaces in parent or return positions
+
 ### 1.0.2
 
 - Better prettier detection (and fallback) for the generated files, re #14

--- a/src/serviceFile.codefacts.ts
+++ b/src/serviceFile.codefacts.ts
@@ -111,26 +111,24 @@ const getResolverInformationForDeclaration = (initialiser: tsMorph.Expression | 
 			}
 		}
 
+		let isObjLiteral = false
+		if (initialiser.isKind(tsMorph.SyntaxKind.ArrowFunction)) {
+			const isSingleLiner = initialiser.getStatements().length === 0
+			if (isSingleLiner) isObjLiteral = isLiteral(initialiser.getBody())
+		}
+
 		return {
 			funcArgCount: params.length,
 			isFunc: true,
 			isAsync: initialiser.isAsync(),
 			isUnknown: false,
-			isObjLiteral: false,
+			isObjLiteral,
 			infoParamType,
 		}
 	}
 
 	// resolver is a raw obj
-	if (
-		initialiser.isKind(tsMorph.SyntaxKind.ObjectLiteralExpression) ||
-		initialiser.isKind(tsMorph.SyntaxKind.StringLiteral) ||
-		initialiser.isKind(tsMorph.SyntaxKind.NumericLiteral) ||
-		initialiser.isKind(tsMorph.SyntaxKind.TrueKeyword) ||
-		initialiser.isKind(tsMorph.SyntaxKind.FalseKeyword) ||
-		initialiser.isKind(tsMorph.SyntaxKind.NullKeyword) ||
-		initialiser.isKind(tsMorph.SyntaxKind.UndefinedKeyword)
-	) {
+	if (isLiteral(initialiser)) {
 		return {
 			funcArgCount: 0,
 			isFunc: false,
@@ -149,3 +147,13 @@ const getResolverInformationForDeclaration = (initialiser: tsMorph.Expression | 
 		isObjLiteral: false,
 	}
 }
+
+const isLiteral = (node: tsMorph.Node) =>
+	node.isKind(tsMorph.SyntaxKind.ObjectLiteralExpression) ||
+	node.isKind(tsMorph.SyntaxKind.StringLiteral) ||
+	node.isKind(tsMorph.SyntaxKind.TemplateExpression) ||
+	node.isKind(tsMorph.SyntaxKind.NumericLiteral) ||
+	node.isKind(tsMorph.SyntaxKind.TrueKeyword) ||
+	node.isKind(tsMorph.SyntaxKind.FalseKeyword) ||
+	node.isKind(tsMorph.SyntaxKind.NullKeyword) ||
+	node.isKind(tsMorph.SyntaxKind.UndefinedKeyword)

--- a/src/serviceFile.ts
+++ b/src/serviceFile.ts
@@ -319,6 +319,7 @@ function returnTypeForResolver(mapper: TypeMapper, field: graphql.GraphQLField<u
 	const all = `${tType} | Promise<${tType}> | (() => Promise<${tType}>)`
 
 	if (resolver.isFunc && resolver.isAsync) returnType = `Promise<${tType}>`
+	else if (resolver.isFunc && !resolver.isObjLiteral) returnType = tType
 	else if (resolver.isFunc) returnType = all
 	else if (resolver.isObjLiteral) returnType = tType
 	else if (resolver.isUnknown) returnType = all

--- a/src/tests/bugs/parentCanBeGraphQLObject.test.ts
+++ b/src/tests/bugs/parentCanBeGraphQLObject.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from "vitest"
+
+import { getDTSFilesForRun, graphql, prisma } from "../testRunner.js"
+
+it("Uses GraphQL objects when prisma objects are not available for resolver parents", () => {
+	const prismaSchema = prisma`
+	model Game {
+		id Int @id @default(autoincrement())
+	}
+`
+
+	const sdl = graphql`
+		type Game {
+			id: Int!
+		}
+
+		type Puzzle {
+			id: Int!
+		}
+	`
+
+	const gamesService = `
+import { db } from "src/lib/db";
+
+export const Puzzle = {
+  id: "",
+};
+`
+
+	const { vfsMap } = getDTSFilesForRun({ sdl, gamesService, prismaSchema })
+	const dts = vfsMap.get("/types/games.d.ts")!
+	expect(dts.trim()).toMatchInlineSnapshot(`
+		"import type { Puzzle as SPuzzle } from \\"./shared-return-types\\";
+
+		export interface PuzzleTypeResolvers {
+		  /** SDL: id: Int! */
+		  id: number;
+		}
+
+		type PuzzleAsParent = SPuzzle & { id: () => number };"
+	`)
+})

--- a/src/tests/bugs/returnObjectCanBeGraphQLInterfaces.test.ts
+++ b/src/tests/bugs/returnObjectCanBeGraphQLInterfaces.test.ts
@@ -48,11 +48,9 @@ export const Game = {
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ) => RTNode | Promise<RTNode> | (() => Promise<RTNode>);
+		  ) => RTNode;
 		}
 
-		type GameAsParent = PGame & {
-		  puzzle: () => RTNode | Promise<RTNode> | (() => Promise<RTNode>);
-		};"
+		type GameAsParent = PGame & { puzzle: () => RTNode };"
 	`)
 })

--- a/src/tests/bugs/returnObjectCanBeGraphQLInterfaces.test.ts
+++ b/src/tests/bugs/returnObjectCanBeGraphQLInterfaces.test.ts
@@ -1,0 +1,58 @@
+import { expect, it } from "vitest"
+
+import { getDTSFilesForRun, graphql, prisma } from "../testRunner.js"
+
+it("The retunr type can be a graphql interface", () => {
+	const prismaSchema = prisma`
+	model Game {
+		id Int @id @default(autoincrement())
+	}
+`
+
+	const sdl = graphql`
+		type Game {
+			id: Int!
+			puzzle: Node!
+		}
+
+		interface Node {
+			id: ID!
+		}
+	`
+
+	const gamesService = `
+import { db } from "src/lib/db";
+
+export const Game = {
+  puzzle: () => {}
+};
+`
+
+	const { vfsMap } = getDTSFilesForRun({ sdl, gamesService, prismaSchema })
+	const dts = vfsMap.get("/types/games.d.ts")!
+	expect(dts.trim()).toMatchInlineSnapshot(`
+		"import type { Game as PGame } from \\"@prisma/client\\";
+		import type { GraphQLResolveInfo } from \\"graphql\\";
+
+		import type { RedwoodGraphQLContext } from \\"@redwoodjs/graphql-server/dist/types\\";
+
+		import type { Node as RTNode } from \\"./shared-return-types\\";
+		import type { Node } from \\"./shared-schema-types\\";
+
+		export interface GameTypeResolvers {
+		  /** SDL: puzzle: Node! */
+		  puzzle: (
+		    args?: undefined,
+		    obj?: {
+		      root: GameAsParent;
+		      context: RedwoodGraphQLContext;
+		      info: GraphQLResolveInfo;
+		    }
+		  ) => RTNode | Promise<RTNode> | (() => Promise<RTNode>);
+		}
+
+		type GameAsParent = PGame & {
+		  puzzle: () => RTNode | Promise<RTNode> | (() => Promise<RTNode>);
+		};"
+	`)
+})

--- a/src/tests/features/preferPromiseFnWhenKnown.test.ts
+++ b/src/tests/features/preferPromiseFnWhenKnown.test.ts
@@ -18,6 +18,7 @@ model Game {
 			awayTeamID: Int!
 
 			summarySync: String!
+			summarySyncBlock: String!
 			summaryAsync: String!
 			summary: String!
 		}
@@ -43,6 +44,9 @@ export const gameObj = {}
 export const Game = {
   summary: "",
   summarySync: () => "",
+  summarySyncBlock: () => {
+  	return ""
+  },
   summaryAsync: async () => ""
 };
 `
@@ -67,7 +71,7 @@ export const Game = {
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ): RTGame | null | Promise<RTGame | null> | (() => Promise<RTGame | null>);
+		  ): RTGame | null;
 		}
 
 		/** SDL: gameAsync: Game */
@@ -91,7 +95,7 @@ export const Game = {
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ): RTGame | null | Promise<RTGame | null> | (() => Promise<RTGame | null>);
+		  ): RTGame | null;
 		}
 
 		/** SDL: gameAsync2Arg: Game */
@@ -103,7 +107,7 @@ export const Game = {
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ): RTGame | null | Promise<RTGame | null> | (() => Promise<RTGame | null>);
+		  ): RTGame | null;
 		}
 
 		/** SDL: gameObj: Game */
@@ -132,6 +136,16 @@ export const Game = {
 		    }
 		  ) => string | Promise<string> | (() => Promise<string>);
 
+		  /** SDL: summarySyncBlock: String! */
+		  summarySyncBlock: (
+		    args?: undefined,
+		    obj?: {
+		      root: GameAsParent<Extended>;
+		      context: RedwoodGraphQLContext;
+		      info: GraphQLResolveInfo;
+		    }
+		  ) => string;
+
 		  /** SDL: summaryAsync: String! */
 		  summaryAsync: (
 		    args?: undefined,
@@ -146,6 +160,7 @@ export const Game = {
 		type GameAsParent<Extended> = PGame & {
 		  summary: () => string;
 		  summarySync: () => string | Promise<string> | (() => Promise<string>);
+		  summarySyncBlock: () => string;
 		  summaryAsync: () => Promise<string>;
 		} & Extended;"
 	`)

--- a/src/tests/features/returnTypePositionsWhichPreferPrisma.test.ts
+++ b/src/tests/features/returnTypePositionsWhichPreferPrisma.test.ts
@@ -58,7 +58,7 @@ export const Game = {
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ): RTGame | null | Promise<RTGame | null> | (() => Promise<RTGame | null>);
+		  ): RTGame | null;
 		}
 
 		export interface GameTypeResolvers {

--- a/src/tests/features/supportRefferingToEnumsOnlyInSDL.test.ts
+++ b/src/tests/features/supportRefferingToEnumsOnlyInSDL.test.ts
@@ -55,7 +55,7 @@ export const Game: GameResolvers = {};
 		      context: RedwoodGraphQLContext;
 		      info: GraphQLResolveInfo;
 		    }
-		  ): RTGame[] | Promise<RTGame[]> | (() => Promise<RTGame[]>);
+		  ): RTGame[];
 		}
 
 		export interface GameTypeResolvers {}

--- a/src/typeMap.ts
+++ b/src/typeMap.ts
@@ -86,6 +86,7 @@ export const typeMapper = (context: AppContext, config: { preferPrismaModels?: t
 			}
 
 			if (graphql.isInterfaceType(type)) {
+				referencedGraphQLTypes.add(type.name)
 				return prefix + type.name
 			}
 


### PR DESCRIPTION

- Improvements to codegen when using GraphQL types and interfaces in parent or return positions

- When a resolver is simply a fn to a literal, narrow to that exact type in the codegen (instead of keeping the optional promise type)